### PR TITLE
unquoted attribute values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a bug where the unquoted attribute values were erroneously parsed via `edn/read-string`.
+
 ## v0.1.1
 
 ### Added

--- a/src/taipei_404/html.cljc
+++ b/src/taipei_404/html.cljc
@@ -17,9 +17,10 @@
   self-closing-tag = <'<'> <spaces>? tag-name attributes? <spaces>? <'/>'>
   tag-name = #'[^ />]+'
   attributes = (<spaces> attribute)+
-  attribute = attribute-name (<'='> attribute-value)?
+  attribute = attribute-name (<'='> (unquoted-attribute-value | quoted-attribute-value))?
   <attribute-name> = #'[^ \t=>]+'
-  <attribute-value> = #'[^ \t>]+' | #'\"[^\"]*\"'
+  <unquoted-attribute-value> = #'[^ \t>]+'
+  quoted-attribute-value = #'\"[^\"]*\"'
   <text> = #'[^<]+'
   spaces = #'[ \t]+'
 ")
@@ -29,23 +30,24 @@
   ([html-str] (html->hiccup html-str nil))
   ([html-str {:as options :keys [comment-keyword]}]
    (->> (html-parser html-str)
-        (insta/transform {:nodes                 (fn [& nodes] (remove nil? nodes))
-                          :comment-element       (fn [& comment]
-                                                   (when (some? comment-keyword)
-                                                     [comment-keyword (apply str comment)]))
-                          :void-element-tag-name keyword
-                          :void-element-tag      (fn ([tag-name] [tag-name])
-                                                     ([tag-name attributes] [tag-name attributes]))
-                          :open-close-tags       (fn [opening-tag nodes _closing-tag]
-                                                   (into opening-tag nodes))
-                          :opening-tag           (fn ([tag-name] [tag-name])
-                                                     ([tag-name attributes] [tag-name attributes]))
-                          :self-closing-tag      (fn ([tag-name] [tag-name])
-                                                     ([tag-name attributes] [tag-name attributes]))
-                          :tag-name              keyword
-                          :attributes            (fn [& attributes]
-                                                   (into {} attributes))
-                          :attribute             (fn ([attribute-name]
-                                                      [(keyword attribute-name) true])
-                                                     ([attribute-name attribute-value]
-                                                      [(keyword attribute-name) (edn/read-string attribute-value)]))}))))
+        (insta/transform {:nodes                    (fn [& nodes] (remove nil? nodes))
+                          :comment-element          (fn [& comment]
+                                                      (when (some? comment-keyword)
+                                                        [comment-keyword (apply str comment)]))
+                          :void-element-tag-name    keyword
+                          :void-element-tag         (fn ([tag-name] [tag-name])
+                                                        ([tag-name attributes] [tag-name attributes]))
+                          :open-close-tags          (fn [opening-tag nodes _closing-tag]
+                                                      (into opening-tag nodes))
+                          :opening-tag              (fn ([tag-name] [tag-name])
+                                                        ([tag-name attributes] [tag-name attributes]))
+                          :self-closing-tag         (fn ([tag-name] [tag-name])
+                                                        ([tag-name attributes] [tag-name attributes]))
+                          :tag-name                 keyword
+                          :attributes               (fn [& attributes]
+                                                      (into {} attributes))
+                          :attribute                (fn ([attribute-name]
+                                                         [(keyword attribute-name) true])
+                                                        ([attribute-name attribute-value]
+                                                         [(keyword attribute-name) attribute-value]))
+                          :quoted-attribute-value   (fn [quoted-value] (edn/read-string quoted-value))}))))

--- a/test/taipei_404/html_test.cljc
+++ b/test/taipei_404/html_test.cljc
@@ -36,6 +36,10 @@
                :height "600"
                :style  "border:5px solid black"}])
 
+      ;; Element with unquoted attribute
+      "<script src=/foo/bar/baz.js></script>"
+      '([:script {:src "/foo/bar/baz.js"}])
+
       ;; That thing that goes before the html element
       "<!doctype html>"
       '([:!doctype {:html true}])))


### PR DESCRIPTION
Unquoted attribute values were erroneously parsed via `edn/read-string`.