### PR TITLE
Support multiple line comments

### DIFF
--- a/src/taipei_404/html.cljc
+++ b/src/taipei_404/html.cljc
@@ -6,7 +6,7 @@
 (defparser html-parser "
   nodes = node*
   <node> = comment-element | void-element-tag | open-close-tags | self-closing-tag | text
-  comment-element = <'<!--'> (!'-->' #'.')* <'-->'>
+  comment-element = <'<!--'> (!'-->' #'(?s).')* <'-->'>
   void-element-tag = <'<'> void-element-tag-name attributes? <maybe-spaces> <'>'>
   void-element-tag-name = 'area' | 'base' | 'basefont' | 'bgsound' | 'br' | 'col' |
                           'command' | 'embed' | 'frame' | 'hr' | 'img' | 'input' | 'isindex' |

--- a/test/taipei_404/html_test.cljc
+++ b/test/taipei_404/html_test.cljc
@@ -62,7 +62,14 @@
                          {:comment-keyword :!--})))
     (is (= '([:p])
            (html->hiccup "<!--Some useful comment--><p><!--Here also--></p>"
-                          {:comment-keyword nil})))))
+                          {:comment-keyword nil}))))
+  (testing "multiple line comments"
+    (is (= '("\n                         " [:h1 "foo"])
+           (html->hiccup "<!--
+                         some useful
+                         comment
+                         -->
+                         <h1>foo</h1>")))))
 
 (deftest minify-hiccup-test
   (testing "that blank strings are discarded"


### PR DESCRIPTION
I failed to parse html with multiple line comments. This PR might be helpful to fix it.